### PR TITLE
modify BaseARN to use region-agnostic partition names

### DIFF
--- a/awacs/aws.py
+++ b/awacs/aws.py
@@ -45,7 +45,15 @@ class Action(AWSHelperFn):
 
 class BaseARN(AWSHelperFn):
     def __init__(self, service, resource, region='', account=''):
-        self.data = "arn:aws:%s:%s:%s:%s" % (
+        region_string = region.lower()
+        if region_string.startswith("cn-"):
+             aws_partition = "aws-cn"
+        elif region_string.startswith("us-gov"):
+            aws_partition = "aws-us-gov"
+        else:
+            aws_partition = "aws"
+
+        self.data = "arn:" + aws_partition + ":%s:%s:%s:%s" % (
             service, region, account, resource)
 
     def JSONrepr(self):


### PR DESCRIPTION
see AWS Docs:
http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-arns

test with sample code:
import awacs.acm
import awacs.cloudformation

def print_region_arns(my_region):
foo = awacs.acm.ARN(region=my_region, account="12345678", resource="resourcename").JSONrepr()
boo = awacs.cloudformation.ARN(region=my_region, account="12345678", resource="resourcename").JSONrepr()
print(my_region + " ARNs:\n" + foo + "\n" + boo + "\n")

regions = ["us-east-1", "us-gov-west-1", "eu-east-1", "cn-west-1"]
for my_region in regions:
print_region_arns(my_region)